### PR TITLE
Tidy-up of the Halthir character

### DIFF
--- a/James/Halthir Dasami.md
+++ b/James/Halthir Dasami.md
@@ -10,7 +10,7 @@
 | Attribute     | Base  | BP    | Score | Adjusted  |
 | ---------     | ----: | ----: | ----: | -------:  |
 | Body          | 1     | 10    | 2     | 3         |
-| Agility       | 2     | 10    | 2     | 2         |
+| Agility       | 2     | 10    | 3     | 3         |
 | Reaction      | 1     | 10    | 2     | 3         |
 | Strength      | 1     | 0     | 1     | 1         |
 | Charisma      | 3     | 10    | 4     | 4         |

--- a/James/Halthir Dasami.md
+++ b/James/Halthir Dasami.md
@@ -1,126 +1,143 @@
 # Halthir Dasami (Adept)
 
-* Name **Halthir Dasami** 
-* metatype **Elf** 
+* Name **Halthir Dasami**
+* Metatype **Elf**
 * **Adept** quality
 * **Middle** lifestyle
 
-## Attributes   150
+## Attributes
 
 | Attribute     | Base  | BP    | Score | Adjusted  |
 | ---------     | ----: | ----: | ----: | -------:  |
-| Body          | 1     | 10    | 3     | 2         |
+| Body          | 1     | 10    | 2     | 2         |
 | Agility       | 2     | 10    | 2     | 5         |
 | Reaction      | 1     | 10    | 2     | 5         |
-| Strength      | 3     | 0     | 3     | 2         |
-| Charisma      | 2     | 10    | 2     | 5         |
+| Strength      | 1     | 0     | 1     | 2         |
+| Charisma      | 3     | 10    | 4     | 5         |
 | Intuition     | 1     | 30    | 4     | 2         |
 | Logic         | 1     | 30    | 4     | 2         |
-| Willpower     | 2     | 30    | 5     | 2         |
+| Willpower     | 1     | 30    | 4     | 2         |
 | Edge          | 1     | 0     | 1     | 2         |
-| Magic			| 1		|		|		| 5			|
+| Magic         | 1     | 40    | 5     | 5         |
 
-## Qualities  -5
+**Total**: 170
 
-35 Negative (max 35), 30 Positive (Max 35)
+## Qualities
 
-| Quality             | Rating  | BP    |  Notes            |
-| ---------           | ----:   | ----: | ---------         |
-| Sensitive System    |         | -15   | pg 95             |
-| SINer               |         | -5    | pg 95             |
-| Records on File	  |			| -10	| RC pg 109			|
-| Allergy			  |			| -5    | pg 90
-| Elf	              |         |  25   |                   |
-| Adept		          |         |  5    | pg 90				|
-| Low Light Vision	  |			|		|					|
+| Quality           | Rating    | BP    |  Notes    |
+| ---------         | ----:     | ----: | --------- |
+| Sensitive System  |           | -15   | SR4A p95  |
+| SINer             |           | -5    | SR4A p95  |
+| Records on File   |           | -10   | RC p109   |
+| Allergy           |           | -5    | SR4A p90  |
+| Adept             |           |  5    | SR4A p90  |
 
-## Active skill Groups  80
+**Total:** -30
+
+## Active skills
+
+**Total BP**: 94 _(grand total for both groups and individual skills)_
+
+### Skill groups
 
 | Skill             | Rating    |
 | -----             | -----:    |
 | Influence         | 2         |
-| Stealth			| 1         |
+| Stealth           | 1         |
 
+**Total BP**: 30
 
-## Active skills    10
+### Individual skills
 
 | Skill             | Rating    |
 | -----             | -----:    |
-| Perception		| 4		    |
+| Perception        | 4         |
 | Pistols           | 6         |
 | Blades            | 6         |
 
+**Total BP**: 64
+
 ## Knowledge skills 
 
-(L+I)*3 = 12 free points
+(L+I)*3 = 24 free points
 
-| Skill                             | Rating    | Category      |
-| -----                             | -----:    | --------      |
-| Business						    | 3         | Academic      |
-| Economics					        | 3         | Academic      |
-| Syndicates						| 3         | Street	    |
-| Area knowledge (Seattle)			| 3         | Street	    |
-|                                   |           |               |
-| English                           | N         |  Language     |
-| Japanese                          | 3 (5)     |  Language     |
-| Cantonese                         | 3 (5)     |  Language     |
-| Or'Zet							| 3 (5)     |  Language     |
-| Spanish							| 3 (5)     |  Language     |
-| Sperethiel                        | 4 (6)     |  Language     |
-| Sperethiel (Read/Write)			| 4 (6)     |  Language     |
+| Skill                         | Rating    | Category  |
+| -----                         | -----:    | --------  |
+| Business                      | 3         | Academic  |
+| Economics                     | 3         | Academic  |
+| Syndicates                    | 3         | Street    |
+| Area knowledge (Seattle)      | 3         | Street    |
 
+### Language skills
+
+| Language                      | Rating    |
+| -----                         | -----:    |
+| English                       | N         |
+| Japanese                      | 3 (5)     |
+| Cantonese                     | 3 (5)     |
+| Or'Zet                        | 3 (5)     |
+| Spanish                       | 3 (5)     |
+| Sperethiel                    | 4 (6)     |
+| Sperethiel (Read/Write)       | 4 (6)     |
+
+**Total BP**: 16 _(above free knowledge skill allowance)_
 
 ## Contacts
-| Name								| Connection	| Loyalty	|
-| -----								| ----------	| -------	|
-| Business Contact					| 2				| 1			|
-| Business Contact 2				| 2				| 1			|
-| Mother							| 1				| 4			|
-| Sister							| 2				| 2			|
+
+| Name                                                          | Connection    | Loyalty   |
+| -----                                                         | ---------:    | ------:   |
+| Area Macrotechnology Auditor: Ruri Matsunaga (Troll)          | 2             | 1         |
+| Horizon Assistant Marketing Editor: Maria Gracia Ros (Elf)    | 2             | 1         |
+| Mother: Freya Dasami (nee Cireson)                            | 1             | 4         |
+| Sister: Nalia Dasami                                          | 2             | 2         |
+
+**Total BP**: 15
 
 ## Adept Powers
 
-| Power								|  Rating	|	Points  |	Reference	
-| -----								|  -----:   |	------	|	---------	
-| Attribute Boost					| 1         |	0.25	| pg 195
-| Commanding Voice					|			|	0.25	| SM pg 176
-| Enhanced Perception				| 1         |	0.25	| pg 195
-| Facial Sculpt						| 1         |	0.25	| SM pg 177
-| Improved Physical Attribute (BOD)	| 1         |	0.75	| pg 196
-| Improved Reflexes		            |			|	1.50	| pg 196
-| Kinesics				            | 1         |	0.50	| pg 196
-| Linguistics		                |		    |	0.25	| SM pg 177
-| Spell Resistance		            | 1         |	0.50	| pg 197
-| Voice Control			            |	        |	0.50	| pg 197
+| Power                             | Rating    | Points    | Reference |
+| -----                             | -----:    | -----:    | --------- |
+| Attribute Boost                   | 1         | 0.25      | SR4A p195 |
+| Commanding Voice                  |           | 0.25      | SM p176   |
+| Enhanced Perception               | 1         | 0.25      | SR4A p195 |
+| Facial Sculpt                     | 1         | 0.25      | SM p177   |
+| Improved Physical Attribute (BOD) | 1         | 0.75      | SR4A p196 |
+| Improved Reflexes                 |           | 1.50      | SR4A p196 |
+| Kinesics                          | 1         | 0.50      | SR4A p196 |
+| Linguistics                       |           | 0.25      | SM p177   |
+| Spell Resistance                  | 1         | 0.50      | SR4A p197 |
+| Voice Control                     |           | 0.50      | SR4A p197 |
+
+**Power points used**: 5
 
 ## Resources, equipment & implants
 
-| Item                                      | Cost �  |
-| ----                                      | -----:  |
-| Lined Coat   (6/4)                        | 700     | 
-| 1 month Medium lifestyle                  |	      |
-| Renraku Sensai Commlink                   | 1000    |
-| Renraku Ichi O/S							| 600     |
-| Trode net									| 50      |
-| Suzuki Mirage								|		  |
-| Colt Manhunter		                    |		  |
-| Streetline Special	                    |		  |
-| Slugs(Regular) Ammo 140 @20� per 10 shots | 280     |
-| Gel     Ammo 20 @30� per 10 shots			| 60      |
+| Item                              | Cost ¥    |
+| ----                              | -----:    |
+| Lined Coat (armour 6/4)           | 700       |
+| 1 month Medium lifestyle          | 5,000     |
+| Renraku Sensai Commlink           | 1,000     |
+| Renraku Ichi O/S                  | 600       |
+| Trode net                         | 50        |
+| Suzuki Mirage                     | 6,500     |
+| Colt Manhunter                    | 300       |
+| Streetline Special                | 100       |
+| Regular ammo × 140 @20¥/10        | 280       |
+| Gel ammo × 20 @30¥/10             | 60        |
 
-
-* Total spend: **� **
-* Starting in-game nuyen: **2d6 � �20**
-* Highest availability used: **x**
+* Total spend: **¥14,590**
+* Starting in-game nuyen: **4d6+4 × ¥100**
+* Highest availability used: **4**
 
 
 ## Build points
 
-| Points    | Description            | Notes             |
-| -----:    | -----------            | :-----            |
-| 190?      | Attributes             |                   |
-| -5        | Qualities              |                   |
-| ?         | Skills                 |                   |
-| ?         | Contacts               |                   |
-| ?         | Resources              | 5k @ 5k / point   |
-| 250       | **Total**              |                   |
+| Points    | Description          | Notes              |
+| -----:    | -----------          | :-----             |
+| 30        | Elf                  |                    |
+| 170       | Attributes           |                    |
+| -30       | Qualities            |                    |
+| 94        | Skills               |                    |
+| 15        | Contacts             |                    |
+| 3         | Resources            | 15k @ 5k / point   |
+| 282       | **Total**            |                    |

--- a/James/Halthir Dasami.md
+++ b/James/Halthir Dasami.md
@@ -9,15 +9,15 @@
 
 | Attribute     | Base  | BP    | Score | Adjusted  |
 | ---------     | ----: | ----: | ----: | -------:  |
-| Body          | 1     | 10    | 2     | 2         |
-| Agility       | 2     | 10    | 2     | 5         |
-| Reaction      | 1     | 10    | 2     | 5         |
-| Strength      | 1     | 0     | 1     | 2         |
-| Charisma      | 3     | 10    | 4     | 5         |
-| Intuition     | 1     | 30    | 4     | 2         |
-| Logic         | 1     | 30    | 4     | 2         |
-| Willpower     | 1     | 30    | 4     | 2         |
-| Edge          | 1     | 0     | 1     | 2         |
+| Body          | 1     | 10    | 2     | 3         |
+| Agility       | 2     | 10    | 2     | 2         |
+| Reaction      | 1     | 10    | 2     | 3         |
+| Strength      | 1     | 0     | 1     | 1         |
+| Charisma      | 3     | 10    | 4     | 4         |
+| Intuition     | 1     | 30    | 4     | 4         |
+| Logic         | 1     | 30    | 4     | 4         |
+| Willpower     | 1     | 30    | 4     | 4         |
+| Edge          | 1     | 0     | 1     | 1         |
 | Magic         | 1     | 40    | 5     | 5         |
 
 **Total**: 170
@@ -73,12 +73,12 @@
 | Language                      | Rating    |
 | -----                         | -----:    |
 | English                       | N         |
-| Japanese                      | 3 (5)     |
-| Cantonese                     | 3 (5)     |
-| Or'Zet                        | 3 (5)     |
-| Spanish                       | 3 (5)     |
-| Sperethiel                    | 4 (6)     |
-| Sperethiel (Read/Write)       | 4 (6)     |
+| Japanese                      | 3         |
+| Cantonese                     | 3         |
+| Or'Zet                        | 3         |
+| Spanish                       | 3         |
+| Sperethiel                    | 4         |
+| Sperethiel (Read/Write)       | 4         |
 
 **Total BP**: 16 _(above free knowledge skill allowance)_
 
@@ -86,7 +86,7 @@
 
 | Name                                                          | Connection    | Loyalty   |
 | -----                                                         | ---------:    | ------:   |
-| Area Macrotechnology Auditor: Ruri Matsunaga (Troll)          | 2             | 1         |
+| Ares Macrotechnology Auditor: Ruri Matsunaga (Troll)          | 2             | 1         |
 | Horizon Assistant Marketing Editor: Maria Gracia Ros (Elf)    | 2             | 1         |
 | Mother: Freya Dasami (nee Cireson)                            | 1             | 4         |
 | Sister: Nalia Dasami                                          | 2             | 2         |
@@ -95,18 +95,18 @@
 
 ## Adept Powers
 
-| Power                             | Rating    | Points    | Reference |
-| -----                             | -----:    | -----:    | --------- |
-| Attribute Boost                   | 1         | 0.25      | SR4A p195 |
-| Commanding Voice                  |           | 0.25      | SM p176   |
-| Enhanced Perception               | 1         | 0.25      | SR4A p195 |
-| Facial Sculpt                     | 1         | 0.25      | SM p177   |
-| Improved Physical Attribute (BOD) | 1         | 0.75      | SR4A p196 |
-| Improved Reflexes                 |           | 1.50      | SR4A p196 |
-| Kinesics                          | 1         | 0.50      | SR4A p196 |
-| Linguistics                       |           | 0.25      | SM p177   |
-| Spell Resistance                  | 1         | 0.50      | SR4A p197 |
-| Voice Control                     |           | 0.50      | SR4A p197 |
+| Power                             | Rating    | Power points  | Reference |
+| -----                             | -----:    | -----:        | --------- |
+| Attribute Boost (AGI)             | 1         | 0.25          | SR4A p195 |
+| Commanding Voice                  |           | 0.25          | SM p176   |
+| Enhanced Perception               | 1         | 0.25          | SR4A p195 |
+| Facial Sculpt                     | 1         | 0.25          | SM p177   |
+| Improved Physical Attribute (BOD) | 1         | 0.75          | SR4A p196 |
+| Improved Reflexes                 | 1         | 1.50          | SR4A p196 |
+| Kinesics                          | 1         | 0.50          | SR4A p196 |
+| Linguistics                       |           | 0.25          | SM p177   |
+| Spell Resistance                  | 1         | 0.50          | SR4A p197 |
+| Voice Control                     |           | 0.50          | SR4A p197 |
 
 **Power points used**: 5
 


### PR DESCRIPTION
There are some issues with this version of the character.  I have also tidied it up a little and filled in some of the blanks from reference material or calculations.  That includes _fixing_ some of the base stats which Elf grants you.

## Overspend

There's a **32 build point over-spend** here.  Some of the issues below might explain it though.

## No BP spent on Magic

There were _no BP recorded as spent on your Magic attribute_.  That accounts for **40 BP missing**, assuming you're going for a Magic of 5.

## Possible confusion on attribute spend

I might have misinterpreted your spend on other attribute points.  I've corrected the base scores, which I presume were left-over from copy-paste of a different character.  I then used the spent-build-points amount as the source of truth.  So, if that was not correct then I might have "corrected" your attributes and made them incorrect in the process.

## Elf is not a quality

Makes no material difference, but "Elf" is not a Quality and so doesn't count towards your limit.  It still costs 30 BP though.

## Active skills above chargen caps

You've exceeded the skills ranks in active skills permitted to a starting-character.  SR4A p84 states:

> The maximum skill rating for starting characters is either one skill at Rating 6 (with the rest at Rating 4 or less) or two skills at Rating 5 (with the rest at Rating 4 or less). Your character cannot start with both one Rating 6 skill and two Rating 5 skills.

But you've got two active skills with Rating 6.

## I presume Attribute Boost is still for AGI?

Attribute Boost adept power must be bought for a specific attribute.  I presume it is still intended to be for Agility?

## Ammo must be purchased separately for your guns

Ammo is purchased per ranged weapon class.  For example All heavy pistol ammo is compatible with all heavy pistols, but is incompatible with light or holdout pistols.  Your two guns are a heavy pistol and a holdout pistol.  So their ammo needs to be indicated separately because it's not interchangeable.